### PR TITLE
Added dynamic resizing of pause menu and fixed runtime errors for it

### DIFF
--- a/JRPGProject (School)/JRPGProject/JRPGProject.resource_order
+++ b/JRPGProject (School)/JRPGProject/JRPGProject.resource_order
@@ -29,10 +29,10 @@
     {"name":"Timelines","order":8,"path":"folders/Timelines.yy",},
   ],
   "ResourceOrderSettings":[
-    {"name":"obj_battle_manager","order":4,"path":"objects/obj_battle_manager/obj_battle_manager.yy",},
     {"name":"ft_gui","order":1,"path":"fonts/ft_gui/ft_gui.yy",},
     {"name":"obj_battle_dialogue","order":5,"path":"objects/obj_battle_dialogue/obj_battle_dialogue.yy",},
     {"name":"obj_battle_enemy","order":3,"path":"objects/obj_battle_enemy/obj_battle_enemy.yy",},
+    {"name":"obj_battle_manager","order":4,"path":"objects/obj_battle_manager/obj_battle_manager.yy",},
     {"name":"obj_battle_menu_test","order":2,"path":"objects/obj_battle_menu_test/obj_battle_menu_test.yy",},
     {"name":"obj_dialogue","order":3,"path":"objects/obj_dialogue/obj_dialogue.yy",},
     {"name":"obj_enemy_plate_1","order":3,"path":"objects/obj_enemy_plate_1/obj_enemy_plate_1.yy",},

--- a/JRPGProject (School)/JRPGProject/objects/obj_manager/Step_2.gml
+++ b/JRPGProject (School)/JRPGProject/objects/obj_manager/Step_2.gml
@@ -1,22 +1,17 @@
 /// @description Pause State
 if (keyboard_check_pressed(vk_escape)) {
 	if (!(global.isPaused) && !(global.isDialogue)) {
-		global.isPaused = true;
-		obj_map_mover.moveSpd = 0; // Stop player movement
-		
-		// Get the position of the camera, then add the offsets to create
-		// pause menu object. So that the pause menu is positioned with
-		// respect to the camera position
-		var x_offset = 20;
-		var y_offset = 10;
-		var vx = camera_get_view_x(view_camera[0]) + x_offset;
-		var vy = camera_get_view_y(view_camera[0]) + y_offset;
-		
-		instance_create_layer(vx, vy,"Instances", obj_pause_menu);
+		if ((room != rm_start_test) && (room != rm_battle_test)) {
+			global.isPaused = true;
+			obj_map_mover.moveSpd = 0; // Stop player movement
+			
+			// Make the instance out of bounds
+			instance_create_layer(-200, -200,"Instances", obj_pause_menu);
+		}
 	}
 	else {
 		global.isPaused = false;
-		instance_destroy(obj_pause_menu);
-		obj_map_mover.moveSpd = 1; // Set player speed back
+		if instance_exists(obj_pause_menu) { instance_destroy(obj_pause_menu); }
+		if instance_exists(obj_map_mover) { obj_map_mover.moveSpd = 1; }
 	}
 }

--- a/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Create_0.gml
+++ b/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Create_0.gml
@@ -2,6 +2,7 @@
 
 // Set up variables
 draw_set_color(c_black); // Sets default text drawing color
+draw_set_font(ft_basic); // Sets default drawing font
 
 // Menu level 0
 pauseMenuText[0, 0] = "Party";

--- a/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Draw_64.gml
+++ b/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Draw_64.gml
@@ -1,17 +1,41 @@
 /// @description Draw the Pause Menu GUI
+// Temp font storage
+var oldFont = draw_get_font();
+draw_set_font(ft_basic);
+
+// Dynamically size the pause menu sprite based on Menu Level
+var get_string_w = 0;
+var temp_string_w = 0;
+
+for (var i=0; i<pauseMenuLength; i++) {
+	get_string_w = string_width(pauseMenuText[pauseMenuLevel,i]+" <");
+	if (temp_string_w < get_string_w) { temp_string_w = get_string_w; }
+}
+var new_sprite_w = temp_string_w+25; // new sprite width
+var new_sprite_h = (pauseMenuLength*22)+10; // new sprite heigth
+
+dx = 43; // where to draw the sprite at x corrdinate
+dy = 25; // where to draw the sprite at y coordinate
+xs = new_sprite_w/sprite_width; // xscale of sprite
+ys = new_sprite_h/sprite_width; // yscale of sprite
+
+draw_sprite_ext(sprite_index,image_index,dx,dy,xs,ys,0,c_white,1);
 
 // Draw the text
 for (var i=0; i<pauseMenuLength; i++) { // Sets color based on current text position, then draws that row of text.
 	
 	if (pauseMenuPos = i) { // Set color
-		draw_set_color(c_lime);	 // Highlighted color
+		draw_set_color(c_black); // Highlighted color
+		draw_text(55, 30+(i*22), pauseMenuText[pauseMenuLevel,i]+" <");
 	} else {
-		draw_set_color(c_green); // Not highlighted color
+		draw_set_color(c_grey); // Not highlighted color
+		draw_text(55, 30+(i*22), pauseMenuText[pauseMenuLevel,i]);
 	}
-	
-	// Draw text for the current submenu
-	draw_text(50, 40+(i*22), pauseMenuText[pauseMenuLevel,i]);
+
 }
 
 // Reset color back to black
 draw_set_color(c_black);
+
+// Reset the font. ALWAYS HAVE AS LAST LINE
+draw_set_font(oldFont);

--- a/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Step_0.gml
+++ b/JRPGProject (School)/JRPGProject/objects/obj_pause_menu/Step_0.gml
@@ -14,6 +14,7 @@ pauseMenuPos += down_key_pressed - up_key_pressed;
 if pauseMenuPos >= pauseMenuLength {pauseMenuPos = 0};
 if pauseMenuPos < 0 {pauseMenuPos = pauseMenuLength - 1};
 
+
 // Statement for selecting a highlighted option for each submenu
 if (space_key_pressed || z_key_pressed) {
 	switch (pauseMenuLevel) {


### PR DESCRIPTION
Added dynamic resizing of the pause menu based on menu level it's on, can be potentially customized to support fixed sizes for certain submenus (such as the inventory menu) later on. <strike>Also fixed a runtime error for when the game pauses, it tries to set the obj_map_mover (player controlled object) speed to 0 and the instance of it doesn't exist. So I made it so that the game can only pause if it's not in the main menu or battle test room and it won't set the speed values of obj_map_mover if it doesn't yet exist.</strike>

Edit: For the strikethrough text, the obj_map_mover parts of my code will be removed in a future pull request as they are redundant, and the obj_map_mover object already has its own code for pausing I forgot to ask/check for previously. So the actual fix in this pull request makes it so that pausing on the main menu and the battle room is disabled, and the pause menu instance doesn't get destroyed when it doesn't exist yet when global.isPaused is still set to false.