### PR TITLE
Fixed Issue Where Invalid Enemy Was Chosen

### DIFF
--- a/JRPGProject (School)/JRPGProject/objects/battle_target_chooser/Step_0.gml
+++ b/JRPGProject (School)/JRPGProject/objects/battle_target_chooser/Step_0.gml
@@ -16,8 +16,8 @@ if(global.needToChoose == 1)
 		} else {
 			y = enemyYpos;
 			
-			if(global.battlersActive[3] == 0) chosenTarget = 2;
 			if(global.battlersActive[4] == 0) chosenTarget = 1;
+			if(global.battlersActive[3] == 0) chosenTarget = 2;
 		}
 		
 		x = xValues[chosenTarget];


### PR DESCRIPTION
* Was an issue where if the first and middle enemy were knocked out, it would still put cursor on middle enemy even though it was defeated
* This has been fixed - it will now default to the last enemy in this case
* I did ask the teacher and he said it's fine to do a minor bug fix like this